### PR TITLE
replace instance cache with lru-cache or settingModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ let cache = {
       value: value
     };
   }
-}
+};
 
 const DingTalk = require('node-dingtalk');
 const dingtalk = new DingTalk({

--- a/README.md
+++ b/README.md
@@ -32,11 +32,42 @@ $ npm i node-dingtalk --save
 const DingTalk = require('node-dingtalk');
 const dingtalk = new DingTalk({
   corpid: '',
-  corpsecret: ''
+  corpsecret: ''  
 });
 
 const deparment = dingtalk.department.get('1');
 console.log(deparment);
+```
+
+### Cache example
+
+> cluster 下换成 Redis 等外部存储从而降低获取 AccessToken 频率
+
+```javascript
+let CACHE = {};
+
+let cache = {
+  get: (key)=>{    
+    if(CACHE[key] && (CACHE[key].expired < Date.now())){
+      return CACHE[key].value;
+    }else{
+      return null;
+    }      
+  },
+  set: (key, value, maxAge)=>{
+    CACHE[key] = {
+      expired: maxAge,
+      value: value
+    };
+  }
+}
+
+const DingTalk = require('node-dingtalk');
+const dingtalk = new DingTalk({
+  corpid: '',
+  corpsecret: ''
+  cache: cache
+});
 ```
 
 ## Api

--- a/lib/api/client.js
+++ b/lib/api/client.js
@@ -48,7 +48,7 @@ module.exports = class Client {
     this.jsapiTicket = undefined;
     this.jsapiTicketExpireTime = undefined;
 
-    this.cache = options.cache || LRU();    
+    this.cache = options.cache || LRU();
   }
 
   /**

--- a/lib/api/client.js
+++ b/lib/api/client.js
@@ -48,7 +48,7 @@ module.exports = class Client {
     this.jsapiTicket = undefined;
     this.jsapiTicketExpireTime = undefined;
 
-    this.cache = options.cache || LRU();
+    this.cache = options.cache || LRU();    
   }
 
   /**
@@ -198,7 +198,7 @@ module.exports = class Client {
       const response = yield this.get('get_jsapi_ticket', { type: 'jsapi' });
       this.jsapiTicket = response.ticket;
       this.jsapiTicketExpireTime = Date.now() + Math.min(response.expires_in * 1000, this.options.jsapiTicketLifeTime);
-      this.cache.set('accessToken', this.jsapiTicket, this.jsapiTicketExpireTime);
+      this.cache.set('jsapiTicket', this.jsapiTicket, this.jsapiTicketExpireTime);
     }
     return this.jsapiTicket;
   }

--- a/lib/api/client.js
+++ b/lib/api/client.js
@@ -8,6 +8,7 @@ const HttpsAgent = require('agentkeepalive').HttpsAgent;
 const FormStream = require('formstream');
 const urllib = require('urllib');
 const URLLIB = Symbol('URLLIB');
+const LRU = require('lru-cache');
 
 /**
  * 鉴权 && 请求相关 API
@@ -46,6 +47,8 @@ module.exports = class Client {
      */
     this.jsapiTicket = undefined;
     this.jsapiTicketExpireTime = undefined;
+
+    this.cache = options.cache || LRU();
   }
 
   /**
@@ -167,7 +170,8 @@ module.exports = class Client {
    * @return {String} accessToken
    */
   * getAccessToken() {
-    if (!this.accessToken || !this.accessTokenExpireTime || this.accessTokenExpireTime <= Date.now()) {
+    const _accessToken = this.cache.get('accessToken');
+    if (!_accessToken) {
       const url = `${this.options.host}/gettoken`;
       const response = yield this.request(url, {
         data: {
@@ -177,6 +181,7 @@ module.exports = class Client {
       });
       this.accessToken = response.access_token;
       this.accessTokenExpireTime = Date.now() + this.options.accessTokenLifeTime;
+      this.cache.set('accessToken', this.accessToken, this.accessTokenExpireTime);
     }
     return this.accessToken;
   }
@@ -188,10 +193,12 @@ module.exports = class Client {
    * @see https://open-doc.dingtalk.com/doc2/detail.htm?treeId=172&articleId=104966&docType=1
    */
   * getJSApiTicket() {
-    if (!this.jsapiTicket || !this.jsapiTicketExpireTime || this.jsapiTicketExpireTime <= Date.now()) {
+    const _jsapiTicket = this.cache.get('jsapiTicket');
+    if (!_jsapiTicket) {
       const response = yield this.get('get_jsapi_ticket', { type: 'jsapi' });
       this.jsapiTicket = response.ticket;
       this.jsapiTicketExpireTime = Date.now() + Math.min(response.expires_in * 1000, this.options.jsapiTicketLifeTime);
+      this.cache.set('accessToken', this.jsapiTicket, this.jsapiTicketExpireTime);
     }
     return this.jsapiTicket;
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "power-assert": "^1.4.1",
     "proxy-agent": "^2.0.0",
     "supertest": "^2.0.0",
-    "thunk-mocha": "^1.0.4"
+    "thunk-mocha": "^1.0.4",
+    "co": "^4.6.0"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "agentkeepalive": "^2.2.0",
     "co-parallel": "^1.0.0",
     "formstream": "^1.0.0",
+    "lru-cache": "^4.1.1",
     "urllib": "^2.11.1"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

- lru-cache 替代实例内缓存
- options.cache 外部存储

```javascript
let CACHE = {};

let cache = {
  get: (key)=>{    
    if(CACHE[key] && (CACHE[key].expired < Date.now())){
      return CACHE[key].value;
    }else{
      return null;
    }      
  },
  set: (key, value, maxAge)=>{
    CACHE[key] = {
      expired: maxAge,
      value: value
    };
  }
};
```
